### PR TITLE
Add support for changing of the base url

### DIFF
--- a/packages/server/src/clientOptions.js
+++ b/packages/server/src/clientOptions.js
@@ -1,3 +1,9 @@
-export const clientOptions = {
+const clientOptions = {
   apiHostname: process.env.BASE_URL
 };
+
+const oauthClientOptions = {
+  apiHostname: process.env.OAUTH_URL
+};
+
+export { clientOptions, oauthClientOptions };

--- a/packages/server/src/clientOptions.js
+++ b/packages/server/src/clientOptions.js
@@ -1,0 +1,3 @@
+export const clientOptions = {
+  apiHostname: process.env.BASE_URL
+};

--- a/packages/server/src/routes/auth.js
+++ b/packages/server/src/routes/auth.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { token, refresh, authorize, revoke, info } from '@procore/js-sdk';
-import { clientOptions } from '../clientOptions';
+import { oauthClientOptions } from '../clientOptions';
 
 function setSession(req, result) {
   req.session.accessToken = result.access_token;
@@ -26,7 +26,7 @@ authRouter.get('/', (_req, res) => {
       clientId: process.env.CLIENT_ID,
       uri: process.env.REDIRECT_URI
     },
-    clientOptions
+    oauthClientOptions
     )
   );
 });
@@ -43,7 +43,7 @@ authRouter.get('/callback', async (req, res) => {
     uri: process.env.REDIRECT_URI,
     code: req.query.code
   },
-  clientOptions
+  oauthClientOptions
   );
   setSession(req, result);
   return res.redirect('/');

--- a/packages/server/src/routes/auth.js
+++ b/packages/server/src/routes/auth.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { token, refresh, authorize, revoke, info } from '@procore/js-sdk';
+import { clientOptions } from '../clientOptions';
 
 function setSession(req, result) {
   req.session.accessToken = result.access_token;
@@ -24,7 +25,9 @@ authRouter.get('/', (_req, res) => {
     authorize({
       clientId: process.env.CLIENT_ID,
       uri: process.env.REDIRECT_URI
-    })
+    },
+    clientOptions
+    )
   );
 });
 
@@ -39,7 +42,9 @@ authRouter.get('/callback', async (req, res) => {
     secret: process.env.CLIENT_SECRET,
     uri: process.env.REDIRECT_URI,
     code: req.query.code
-  });
+  },
+  clientOptions
+  );
   setSession(req, result);
   return res.redirect('/');
 });

--- a/packages/server/src/routes/index.js
+++ b/packages/server/src/routes/index.js
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import { authRouter } from './auth';
 import { proxyRouter } from './proxy';
 import { authorize } from '../middleware';
-import { clientOptions } from '../clientOptions';
 
 const router = Router();
 const authorizer = authorize({ redirectTo: '/oauth/procore/' });
@@ -15,7 +14,6 @@ router.use(authorizer, (req, res, next) => {
       clientId: process.env.CLIENT_ID,
       uri: process.env.REDIRECT_URI
     },
-    clientOptions
   );
 
   const main = {

--- a/packages/server/src/routes/index.js
+++ b/packages/server/src/routes/index.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authRouter } from './auth';
 import { proxyRouter } from './proxy';
 import { authorize } from '../middleware';
+import { clientOptions } from '../clientOptions';
 
 const router = Router();
 const authorizer = authorize({ redirectTo: '/oauth/procore/' });
@@ -14,9 +15,7 @@ router.use(authorizer, (req, res, next) => {
       clientId: process.env.CLIENT_ID,
       uri: process.env.REDIRECT_URI
     },
-    {
-      apiHostname: process.env.OAUTH_URL
-    }
+    clientOptions
   );
 
   const main = {

--- a/packages/server/src/routes/proxy.js
+++ b/packages/server/src/routes/proxy.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { client, oauth } from '@procore/js-sdk';
+import { clientOptions } from '../clientOptions';
 
 let pcorClient = undefined;
 function getClient(accessToken, defaults) {
@@ -7,11 +8,7 @@ function getClient(accessToken, defaults) {
     return pcorClient;
   }
   const authorizer = oauth(accessToken);
-  const options = {
-    apiHostname: process.env.BASE_URL
-  };
-  console.log(`defaults: ${defaults} options: ${options}`);
-  return client(authorizer, defaults, options);
+  return client(authorizer, defaults, clientOptions);
 }
 
 export const proxyRouter = Router();

--- a/packages/server/src/routes/proxy.js
+++ b/packages/server/src/routes/proxy.js
@@ -2,11 +2,15 @@ import { Router } from 'express';
 import { client, oauth } from '@procore/js-sdk';
 
 let pcorClient = undefined;
-function getClient(accessToken, defaults, options) {
+function getClient(accessToken, defaults) {
   if (pcorClient) {
     return pcorClient;
   }
   const authorizer = oauth(accessToken);
+  const options = {
+    apiHostname: process.env.BASE_URL
+  };
+  console.log(`defaults: ${defaults} options: ${options}`);
   return client(authorizer, defaults, options);
 }
 


### PR DESCRIPTION
The sample app was not passing through the `BASE_URL` config to the sdk, so the default values were being used. This sets a clientOptions value that is passed through to the sdk.

Verified:
- Production login and GET calls continue to work
- Sandbox login and GET calls work